### PR TITLE
Added checks for d x n convention

### DIFF
--- a/+precice/@SolverInterface/SolverInterface.m
+++ b/+precice/@SolverInterface/SolverInterface.m
@@ -150,7 +150,7 @@ classdef SolverInterface < handle
         
         % setMeshVertices
         function vertexIds = setMeshVertices(obj,meshID,positions)
-            assert(size(positions, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            obj.checkDimensions(size(positions, 1), obj.getDimensions())
             inSize = size(positions, 2);
             vertexIds = preciceGateway(uint8(46),int32(meshID),int32(inSize),positions);
         end
@@ -163,7 +163,7 @@ classdef SolverInterface < handle
         
         % getMeshVertexIDsFromPositions
         function vertexIds = getMeshVertexIDsFromPositions(obj,meshID,positions)
-            assert(size(positions, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            obj.checkDimensions(size(positions, 1), obj.getDimensions())
             inSize = size(positions, 2);
             vertexIds = preciceGateway(uint8(48),int32(meshID),int32(inSize),positions);
         end
@@ -227,8 +227,8 @@ classdef SolverInterface < handle
                 valueIndices = int32(valueIndices);
             end
             inSize = length(valueIndices);
-            assert(inSize == size(values, 2), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
-            assert(size(values, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            obj.checkDimensions(size(values, 2), inSize)
+            obj.checkDimensions(size(values, 1), obj.getDimensions())
             preciceGateway(uint8(64),int32(dataID),int32(inSize),valueIndices,values);
         end
         
@@ -284,6 +284,12 @@ classdef SolverInterface < handle
         % readScalarData
         function value = readScalarData(obj,dataID,valueIndex)
             value = preciceGateway(uint8(71),int32(dataID),int32(valueIndex));
+        end
+
+        %% Helper functions
+        % Check for dxn convention
+        function checkDimensions(obj, a, b)
+            assert(a ==  b, 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
         end
     end
 end

--- a/+precice/@SolverInterface/SolverInterface.m
+++ b/+precice/@SolverInterface/SolverInterface.m
@@ -150,7 +150,7 @@ classdef SolverInterface < handle
         
         % setMeshVertices
         function vertexIds = setMeshVertices(obj,meshID,positions)
-            assert(size(positions, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            assert(size(positions, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             inSize = size(positions, 2);
             vertexIds = preciceGateway(uint8(46),int32(meshID),int32(inSize),positions);
         end
@@ -163,7 +163,7 @@ classdef SolverInterface < handle
         
         % getMeshVertexIDsFromPositions
         function vertexIds = getMeshVertexIDsFromPositions(obj,meshID,positions)
-            assert(size(positions, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            assert(size(positions, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             inSize = size(positions, 2);
             vertexIds = preciceGateway(uint8(48),int32(meshID),int32(inSize),positions);
         end
@@ -228,7 +228,7 @@ classdef SolverInterface < handle
             end
             inSize = length(valueIndices);
             assert(inSize == size(values, 2), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
-            assert(size(values, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            assert(size(values, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             preciceGateway(uint8(64),int32(dataID),int32(inSize),valueIndices,values);
         end
         
@@ -244,7 +244,7 @@ classdef SolverInterface < handle
                 valueIndices = int32(valueIndices);
             end
             inSize = length(valueIndices);
-            assert(inSize == length(values));
+            assert(inSize == length(values), 'valueIndices and values should must have the same length');
             preciceGateway(uint8(66),int32(dataID),int32(inSize),valueIndices,values);
         end
         

--- a/+precice/@SolverInterface/SolverInterface.m
+++ b/+precice/@SolverInterface/SolverInterface.m
@@ -150,18 +150,20 @@ classdef SolverInterface < handle
         
         % setMeshVertices
         function vertexIds = setMeshVertices(obj,meshID,positions)
+            assert(size(positions, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             inSize = size(positions, 2);
             vertexIds = preciceGateway(uint8(46),int32(meshID),int32(inSize),positions);
         end
         
         % getMeshVertices
         function positions = getMeshVertices(obj,meshID,vertexIds)
-            inSize = size(vertexIds, 2);
+            inSize = length(vertexIds);
             positions = preciceGateway(uint8(47),int32(meshID),int32(inSize),vertexIds);
         end
         
         % getMeshVertexIDsFromPositions
         function vertexIds = getMeshVertexIDsFromPositions(obj,meshID,positions)
+            assert(size(positions, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             inSize = size(positions, 2);
             vertexIds = preciceGateway(uint8(48),int32(meshID),int32(inSize),positions);
         end
@@ -224,7 +226,9 @@ classdef SolverInterface < handle
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
             end
-            inSize = size(valueIndices, 2);
+            inSize = length(valueIndices);
+            assert(inSize == size(values, 2), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            assert(size(values, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             preciceGateway(uint8(64),int32(dataID),int32(inSize),valueIndices,values);
         end
         
@@ -239,7 +243,8 @@ classdef SolverInterface < handle
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
             end
-            inSize = size(valueIndices, 2);
+            inSize = length(valueIndices);
+            assert(inSize == length(values));
             preciceGateway(uint8(66),int32(dataID),int32(inSize),valueIndices,values);
         end
         
@@ -254,7 +259,7 @@ classdef SolverInterface < handle
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
             end
-            inSize = size(valueIndices, 2);
+            inSize = length(valueIndices);
             values = preciceGateway(uint8(68),int32(dataID),int32(inSize),valueIndices);
         end
         
@@ -272,7 +277,7 @@ classdef SolverInterface < handle
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
             end
-            inSize = size(valueIndices, 2);
+            inSize = length(valueIndices);
             values = preciceGateway(uint8(70),int32(dataID),int32(inSize),valueIndices,transpose);
         end
         

--- a/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
+++ b/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
@@ -166,7 +166,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
         
         % setMeshVertices
         function vertexIds = setMeshVertices(obj,meshID,positions)
-            assert(size(positions, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            assert(size(positions, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             inSize = size(positions,2);
             vertexIds = feval(obj.oMexHost,"preciceGateway",uint8(46),int32(meshID),int32(inSize),positions);
         end
@@ -179,7 +179,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
         
         % getMeshVertexIDsFromPositions
         function vertexIds = getMeshVertexIDsFromPositions(obj,meshID,positions)
-            assert(size(positions, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            assert(size(positions, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             inSize = size(positions,2);
             vertexIds = feval(obj.oMexHost,"preciceGateway",uint8(48),int32(meshID),int32(inSize),positions);
         end
@@ -244,7 +244,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
             end
             inSize = length(valueIndices);
             assert(inSize == size(values, 2), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
-            assert(size(values, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            assert(size(values, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             feval(obj.oMexHost,"preciceGateway",uint8(64),int32(dataID),int32(inSize),valueIndices,values);
         end
         
@@ -260,7 +260,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
                 valueIndices = int32(valueIndices);
             end
             inSize = length(valueIndices);
-            assert(inSize == length(values));
+            assert(inSize == length(values), 'valueIndices and values should must have the same length');
             feval(obj.oMexHost,"preciceGateway",uint8(66),int32(dataID),int32(inSize),valueIndices,values);
         end
         

--- a/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
+++ b/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
@@ -166,18 +166,20 @@ classdef SolverInterfaceOOP < precice.SolverInterface
         
         % setMeshVertices
         function vertexIds = setMeshVertices(obj,meshID,positions)
+            assert(size(positions, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             inSize = size(positions,2);
             vertexIds = feval(obj.oMexHost,"preciceGateway",uint8(46),int32(meshID),int32(inSize),positions);
         end
         
         % getMeshVertices
         function positions = getMeshVertices(obj,meshID,vertexIds)
-            inSize = size(vertexIds,2);
+            inSize = length(vertexIds);
             positions = feval(obj.oMexHost,"preciceGateway",uint8(47),int32(meshID),int32(inSize),vertexIds);
         end
         
         % getMeshVertexIDsFromPositions
         function vertexIds = getMeshVertexIDsFromPositions(obj,meshID,positions)
+            assert(size(positions, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             inSize = size(positions,2);
             vertexIds = feval(obj.oMexHost,"preciceGateway",uint8(48),int32(meshID),int32(inSize),positions);
         end
@@ -240,7 +242,9 @@ classdef SolverInterfaceOOP < precice.SolverInterface
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
             end
-            inSize = size(valueIndices, 2);
+            inSize = length(valueIndices);
+            assert(inSize == size(values, 2), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            assert(size(values, 1) ~=  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
             feval(obj.oMexHost,"preciceGateway",uint8(64),int32(dataID),int32(inSize),valueIndices,values);
         end
         
@@ -255,7 +259,8 @@ classdef SolverInterfaceOOP < precice.SolverInterface
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
             end
-            inSize = size(valueIndices, 2);
+            inSize = length(valueIndices);
+            assert(inSize == length(values));
             feval(obj.oMexHost,"preciceGateway",uint8(66),int32(dataID),int32(inSize),valueIndices,values);
         end
         
@@ -270,7 +275,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
             end
-            inSize = size(valueIndices, 2);
+            inSize = length(valueIndices);
             values = feval(obj.oMexHost,"preciceGateway",uint8(68),int32(dataID),int32(inSize),valueIndices);
         end
         
@@ -288,7 +293,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
             end
-            inSize = size(valueIndices, 2);
+            inSize = length(valueIndices);
             values = feval(obj.oMexHost,"preciceGateway",uint8(70),int32(dataID),int32(inSize),valueIndices,transpose);
         end
         

--- a/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
+++ b/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
@@ -166,7 +166,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
         
         % setMeshVertices
         function vertexIds = setMeshVertices(obj,meshID,positions)
-            assert(size(positions, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            obj.checkDimensions(size(positions, 1), obj.getDimensions())
             inSize = size(positions,2);
             vertexIds = feval(obj.oMexHost,"preciceGateway",uint8(46),int32(meshID),int32(inSize),positions);
         end
@@ -179,7 +179,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
         
         % getMeshVertexIDsFromPositions
         function vertexIds = getMeshVertexIDsFromPositions(obj,meshID,positions)
-            assert(size(positions, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            obj.checkDimensions(size(positions, 1), obj.getDimensions())
             inSize = size(positions,2);
             vertexIds = feval(obj.oMexHost,"preciceGateway",uint8(48),int32(meshID),int32(inSize),positions);
         end
@@ -243,8 +243,8 @@ classdef SolverInterfaceOOP < precice.SolverInterface
                 valueIndices = int32(valueIndices);
             end
             inSize = length(valueIndices);
-            assert(inSize == size(values, 2), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
-            assert(size(values, 1) ==  obj.getDimensions(), 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
+            obj.checkDimensions(size(values, 2), inSize)
+            obj.checkDimensions(size(values, 1), obj.getDimensions())
             feval(obj.oMexHost,"preciceGateway",uint8(64),int32(dataID),int32(inSize),valueIndices,values);
         end
         
@@ -300,6 +300,12 @@ classdef SolverInterfaceOOP < precice.SolverInterface
         % readScalarData
         function value = readScalarData(obj,dataID,valueIndex)
             value = feval(obj.oMexHost,"preciceGateway",uint8(71),int32(dataID),int32(valueIndex));
+        end
+
+        %% Helper functions
+        % Check for dxn convention
+        function checkDimensions(obj, a, b)
+            assert(a ==  b, 'The shape of the matrices must be [dim numVertices], where dim is the problem dimension');
         end
     end
 end


### PR DESCRIPTION
Check if MATLAB's arrays are being of shape [dimensions, numVertices]. Also use MATLAB's 'length' instead of 'size', to ensure the code works for both row and column vectors.