### PR TITLE
Add Contents.m file

### DIFF
--- a/Contents.m
+++ b/Contents.m
@@ -1,5 +1,5 @@
 % MATLAB-bindings for coupling library preCICE
-% Version 2.1.0.1 (R2018b) 14-Oct-2020
+% Version 2.1.0.1 (R2018b, R2019a and R2019b) 14-Oct-2020
 %
 % Files
 %   getVersionInformation - 

--- a/Contents.m
+++ b/Contents.m
@@ -1,0 +1,8 @@
+% MATLAB-bindings for coupling library preCICE
+% Version 2.1.0.1 (R2018b) 14-Oct-2020
+%
+% Files
+%   getVersionInformation - 
+
+
+


### PR DESCRIPTION
This PR adds a [Contents.m](https://de.mathworks.com/help/matlab/matlab_prog/create-a-help-summary-contents-m.html) file for the bindings. This file is used to store version number and also information which the user can query with the `help` command in MATLAB.
After compiling the bindings the output of `ver` is as follows:
```
>> ver
-----------------------------------------------------------------------------------------------------
MATLAB Version: 9.5.0.944444 (R2018b)
MATLAB License Number: XXXXXX
Operating System: XXXXXX
Java Version: XXXX
-----------------------------------------------------------------------------------------------------
MATLAB                                                Version 9.5         (R2018b)
Simulink                                              Version 9.2         (R2018b)
Communications Toolbox                                Version 7.0         (R2018b)
Control System Toolbox                                Version 10.5        (R2018b)
DSP System Toolbox                                    Version 9.7         (R2018b)
Image Processing Toolbox                              Version 10.3        (R2018b)
MATLAB-bindings for coupling library preCICE          Version 2.1.0.1     (R2018b)
Optimization Toolbox                                  Version 8.2         (R2018b)
Signal Processing Toolbox                             Version 8.1         (R2018b)
Simulink Control Design                               Version 5.2         (R2018b)
Symbolic Math Toolbox                                 Version 8.2         (R2018b)
```
It can be seen that the MATLAB-bindings and the version number are now included in the list. 
Unfortunately adding the Contents file to the [+precice](https://github.com/precice/matlab-bindings/tree/develop/%2Bprecice) folder to enable a query like `ver precice` does not work and throws the error:
```
>> ver precice
-----------------------------------------------------------------------------------------------------
MATLAB Version: 9.5.0.944444 (R2018b)
MATLAB License Number: 722433
Operating System: Linux 4.15.0-118-generic #119-Ubuntu SMP Tue Sep 8 12:30:01 UTC 2020 x86_64
Java Version: Java 1.8.0_152-b16 with Oracle Corporation Java HotSpot(TM) 64-Bit Server VM mixed mode
-----------------------------------------------------------------------------------------------------
Warning: No properly formatted Contents.m file was found for 'precice'. 
> In ver (line 58) 
```
This has been resolved yet. Putting a Contents file in the main folder of the bindings is the simplest working solution yet to store the Version number. 
This PR closes https://github.com/precice/matlab-bindings/issues/24