### PR TITLE
Add isMeshConnectivityRequired()

### DIFF
--- a/+precice/@SolverInterface/SolverInterface.m
+++ b/+precice/@SolverInterface/SolverInterface.m
@@ -193,6 +193,11 @@ classdef SolverInterface < handle
             preciceGateway(uint8(53),int32(meshID),int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
         end
         
+        % isMeshConnectivityRequired
+        function bool = isMeshConnectivityRequired(meshID)
+            bool = preciceGateway(uint8(54),int32(meshID))
+        end
+        
         %% Data Access
         % hasDataID
         function bool = hasData(obj,dataName,meshID)

--- a/+precice/@SolverInterface/SolverInterface.m
+++ b/+precice/@SolverInterface/SolverInterface.m
@@ -193,7 +193,7 @@ classdef SolverInterface < handle
             preciceGateway(uint8(53),int32(meshID),int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
         end
         
-        % isMeshConnectivityRequired
+        % isMeshConnectivityRequired - EXPERIMENTAL
         function bool = isMeshConnectivityRequired(meshID)
             bool = preciceGateway(uint8(54),int32(meshID))
         end

--- a/+precice/@SolverInterface/SolverInterface.m
+++ b/+precice/@SolverInterface/SolverInterface.m
@@ -193,7 +193,7 @@ classdef SolverInterface < handle
             preciceGateway(uint8(53),int32(meshID),int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
         end
         
-        % isMeshConnectivityRequired - EXPERIMENTAL
+        % isMeshConnectivityRequired
         function bool = isMeshConnectivityRequired(meshID)
             bool = preciceGateway(uint8(54),int32(meshID))
         end

--- a/+precice/@SolverInterface/private/preciceGateway.cpp
+++ b/+precice/@SolverInterface/private/preciceGateway.cpp
@@ -45,6 +45,7 @@ enum class FunctionID {
     setMeshTriangleWithEdges = 51,
     setMeshQuad = 52,
     setMeshQuadWithEdges = 53,
+    isMeshConnectivityRequired = 54,
     
     hasData = 60,
     getDataID = 61,
@@ -311,6 +312,14 @@ public:
                 const TypedArray<int32_t> thirdVertexID = inputs[3];
                 const TypedArray<int32_t> fourthVertexID = inputs[3];
                 interface->setMeshQuadWithEdges(meshID[0],firstVertexID[0],secondVertexID[0],thirdVertexID[0],fourthVertexID[0]);
+                break;
+            }
+            
+            case FunctionID::isMeshConnectivityRequired:
+            {
+                const TypedArray<int32_t> meshID = inputs[1];
+                bool output = interface->isMeshConnectivityRequired(meshID[0]);
+                outputs[0] = factory.createScalar<bool>(output);
                 break;
             }
             

--- a/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
+++ b/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
@@ -209,7 +209,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
             feval(obj.oMexHost,"preciceGateway",uint8(53),int32(meshID),int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
         end
         
-        % isMeshConnectivityRequired - EXPERIMENTAL
+        % isMeshConnectivityRequired
         function bool = isMeshConnectivityRequired(meshID)
             bool = preciceGateway(uint8(54),int32(meshID))
         end

--- a/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
+++ b/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
@@ -209,6 +209,11 @@ classdef SolverInterfaceOOP < precice.SolverInterface
             feval(obj.oMexHost,"preciceGateway",uint8(53),int32(meshID),int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
         end
         
+        % isMeshConnectivityRequired
+        function bool = isMeshConnectivityRequired(meshID)
+            bool = preciceGateway(uint8(54),int32(meshID))
+        end
+                
         %% Data Access
         % hasDataID
         function bool = hasData(obj,dataName,meshID)

--- a/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
+++ b/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
@@ -209,7 +209,7 @@ classdef SolverInterfaceOOP < precice.SolverInterface
             feval(obj.oMexHost,"preciceGateway",uint8(53),int32(meshID),int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
         end
         
-        % isMeshConnectivityRequired
+        % isMeshConnectivityRequired - EXPERIMENTAL
         function bool = isMeshConnectivityRequired(meshID)
             bool = preciceGateway(uint8(54),int32(meshID))
         end


### PR DESCRIPTION
Added Function isMeshConnectivityRequired which is implemented in the preCICE interface but not in the matlab bindings.