### PR TITLE
Insert missing `_ptr` in `getMeshVerticesAndIDs`

### DIFF
--- a/+precice/@SolverInterface/private/preciceGateway.cpp
+++ b/+precice/@SolverInterface/private/preciceGateway.cpp
@@ -333,7 +333,7 @@ public:
                 double* positions = positions_ptr.get();
                 interface->getMeshVertices(meshID[0],size[0],ids,positions);
                 outputs[0] = factory.createArrayFromBuffer<double>({1,size[0]}, std::move(positions_ptr));
-                outputs[1] = factory.createArrayFromBuffer<int32_t>({1,size[0]}, std::move(ids));
+                outputs[1] = factory.createArrayFromBuffer<int32_t>({1,size[0]}, std::move(ids_ptr));
                 break;
             } 
             case FunctionID::isMeshConnectivityRequired:


### PR DESCRIPTION
Closes #35 
This PR fixes an error occuring during compilation. In [`getMeshVerticesAndIDs`](https://github.com/precice/matlab-bindings/blob/6434dc0eb4526ed1b50306341880d36ee43f77dd/%2Bprecice/%40SolverInterface/private/preciceGateway.cpp#L336) in `preciceGateway.cpp` there was a `_ptr` missing, so during compilation the types `int*` and `std::unique_ptr<int32_t>` didn't match.