### PR TITLE
Remove MeshName Argument

### DIFF
--- a/solverdummy/README.md
+++ b/solverdummy/README.md
@@ -12,12 +12,12 @@ No compiling is necessary. You only have to compile the MATLAB bindings.
 
 To run the dummy, open two MATLAB instances and call
 
-* `solverdummy precice-config.xml SolverOne MeshOne`
-* `solverdummy precice-config.xml SolverTwo MeshTwo`
+* `solverdummy precice-config.xml SolverOne`
+* `solverdummy precice-config.xml SolverTwo`
 
-Since `solverdummy` is a MATLAB function and MATLAB treats blank space separated argumenst as char arrays, you can equivalently call
+Since `solverdummy` is a MATLAB function and MATLAB treats blank space separated arguments as char arrays, you can equivalently call
 
-`solverdummy('precice-config.xml','SolverOne','MeshOne')`
+`solverdummy('precice-config.xml','SolverOne')`
 
 and analogously for the second call. 
 Naturally, you may also couple the MATLAB dummy with another dummy instead.

--- a/solverdummy/solverdummy.m
+++ b/solverdummy/solverdummy.m
@@ -1,25 +1,26 @@
 % MATLAB solverdummy.
 % To use it, don't forget to install the matlab bindings and add them to
 % the path
-function solverdummy(configFileName,participantName,meshName)
-    if nargin~=3
-        disp('Usage: solverdummy configFile solverName meshName');
+function solverdummy(configFileName,participantName)
+    if nargin~=2
+        disp('Usage: solverdummy configFile solverName');
         disp('');
         disp('Parameter description');
         disp('  configurationFile: Path and filename of preCICE configuration');
         disp('  participantName:        SolverDummy participant name in preCICE configuration');
-        disp('  meshName:          Mesh in preCICE configuration that carries read and write data');
         return;
     end
     
     if (strcmp(participantName, 'SolverOne'))
         writeDataName = 'dataOne';
         readDataName = 'dataTwo';
+        meshName = 'MeshOne';
     end
     
     if (strcmp(participantName, 'SolverTwo'))
         readDataName = 'dataOne';
         writeDataName = 'dataTwo';
+        meshName = 'MeshTwo';
     end
     
     numVertices = 3;


### PR DESCRIPTION
The mesh name was removed from the input arguments to the other solverdummies in https://github.com/precice/precice/pull/1256. The change is now incorporated in the solverdummy in this repository for consistency.