### PR TITLE
Remove unnecessary warning for absolute path

### DIFF
--- a/solverdummy/README.md
+++ b/solverdummy/README.md
@@ -1,8 +1,6 @@
 # MATLAB solverdummy
 
-This dummy illustrates the use of precice with MATLAB using the MATLAB bindings based on the C data API.
-
-**Please note:** Currently, the MATLAB solverdummy can't be coupled with other solvers unless an exchange directory is specified with its absolute path in the config file. So, if you wish to couple with a different solver, please make sure to modify the config file accordingly.
+This dummy illustrates the use of preCICE with MATLAB using the MATLAB bindings based on the C data API.
 
 ## Compilation
 
@@ -19,5 +17,5 @@ Since `solverdummy` is a MATLAB function and MATLAB treats blank space separated
 
 `solverdummy('precice-config.xml','SolverOne')`
 
-and analogously for the second call. 
+and analogously for the second call.
 Naturally, you may also couple the MATLAB dummy with another dummy instead.


### PR DESCRIPTION
Closes #18 
This PR cleans up the solverdummy README. It contained a warning, that there has to be an absolute path given in the `precice-config.xml` for the solverdummies. This issue was not reproducible, therefore the warning is now removed. 