### PR TITLE
Sync to Precice Version 3.0

### DIFF
--- a/+precice/@SolverInterface/SolverInterface.m
+++ b/+precice/@SolverInterface/SolverInterface.m
@@ -189,11 +189,10 @@ classdef Participant < handle
         % setMeshTriangles
         function setMeshTriangles(obj, meshName, vertices)
             obj.checkDimensions(size(vertices,1), 3)
-            inSize = size(vertices,2);
             if ischar(meshName)
                 meshName = string(meshName);
             end
-            preciceGateway(uint8(49),meshName,int32(size(vertices,2)),vertices);
+            preciceGateway(uint8(49),meshName,vertices);
         end
         
         % setMeshQuad
@@ -210,8 +209,7 @@ classdef Participant < handle
                 meshName = string(meshName);
             end
             obj.checkDimensions(size(vertices,1), 4)
-            inSize = size(vertices,2);
-            preciceGateway(uint8(51),meshName,int32(inSize),vertices);
+            preciceGateway(uint8(51),meshName,vertices);
         end
 
         % setMeshTetrahedron
@@ -225,11 +223,10 @@ classdef Participant < handle
         % setMeshTetrahedra
         function setMeshTetrahedra(obj, meshName, vertices)
             obj.checkDimensions(size(vertices,1), 4)
-            inSize = size(vertices,2);
             if ischar(meshName)
                 meshName = string(meshName);
             end
-            preciceGateway(uint8(53),meshName,int32(inSize),vertices);
+            preciceGateway(uint8(53),meshName,vertices);
         end
 
 
@@ -247,14 +244,13 @@ classdef Participant < handle
                 dataName = string(dataName);
             end
 
-            inSize = length(valueIndices);
             obj.checkDimensions(size(values, 2), inSize)
             obj.checkDimensions(size(values, 1), obj.getDimensions())
-            preciceGateway(uint8(60),meshName,dataName,int32(inSize),valueIndices,values);
+            preciceGateway(uint8(60),meshName,dataName,valueIndices,values);
         end
         
         % readData
-        function values = readData(obj,meshName,dataName,valueIndices)
+        function values = readData(obj,meshName,dataName,valueIndices,relativeReadTime)
             if ~isa(valueIndices,'int32')
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
@@ -266,7 +262,7 @@ classdef Participant < handle
                 dataName = string(dataName);
             end
             inSize = length(valueIndices);
-            values = preciceGateway(uint8(61),meshName,dataName,int32(inSize),valueIndices);
+            values = preciceGateway(uint8(61),meshName,dataName,int32(inSize),valueIndices,relativeReadTime);
         end
 
         % requiresGradientDataFor
@@ -280,8 +276,8 @@ classdef Participant < handle
             bool = preciceGateway(uint8(62),meshName,dataName);
         end
 
-        % writeBlockVectorGradientData
-        function writeBlockVectorGradientData(obj, meshName, dataName, valueIndices, gradientValues)
+        % writeGradientData
+        function writeGradientData(obj, meshName, dataName, valueIndices, gradientValues)
             if ~isa(valueIndices, 'int32')
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
@@ -292,10 +288,9 @@ classdef Participant < handle
             if ischar(dataName)
                 dataName = string(dataName);
             end
-            inSize = length(valueIndices);
             obj.checkDimensions(size(gradientValues, 2), inSize)
             obj.checkDimensions(size(gradientValues, 1), obj.getDimensions() * obj.getDimensions())
-            preciceGateway(uint8(63), meshName,dataName, int32(inSize), valueIndices, gradientValues);
+            preciceGateway(uint8(63),meshName,dataName,valueIndices,gradientValues);
         end
 
         % setMeshAccessRegion
@@ -303,7 +298,7 @@ classdef Participant < handle
             if ischar(meshName)
                 meshName = string(meshName);
             end
-            preciceGateway(uint8(64),meshName,boundingBox)
+            preciceGateway(uint8(64),meshName,boundingBox);
         end
 
         % getMeshVerticesAndIDs

--- a/+precice/@SolverInterface/private/preciceGateway.cpp
+++ b/+precice/@SolverInterface/private/preciceGateway.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <sstream>
 #include <string_view>
-#include "precice/SolverInterface.hpp"
+#include "precice/Participant.hpp"
 
 using namespace matlab::data;
 using matlab::mex::ArgumentList;
@@ -18,19 +18,21 @@ enum class FunctionID {
     advance = 11,
     finalize = 12,
     
-    getDimensions = 20,
-    isCouplingOngoing = 21,
-    isTimeWindowComplete = 22,
-    requiresInitialData = 23,
-    requiresReadingCheckpoint = 24,
-    requiresWritingCheckpoint = 25,
+    getMeshDimensions = 20,
+    getDataDimensions = 21,
+    isCouplingOngoing = 22,
+    isTimeWindowComplete = 23,
+    getMaxTimeStepSize = 24,
+    requiresInitialData = 25,
+    requiresReadingCheckpoint = 26,
+    requiresWritingCheckpoint = 27,
     
     hasMesh = 40,
-    requiresMeshConnectivityFor = 41,
-    requiresGradientDataFor = 42,
+    hasData = 41,
+    requiresMeshConnectivityFor = 42,
     setMeshVertex = 43,
-    getMeshVertexSize = 44,
-    setMeshVertices = 45,
+    setMeshVertices = 44,
+    getMeshVertexSize = 45,
     setMeshEdge = 46,
     setMeshEdges = 47,
     setMeshTriangle = 48,
@@ -39,34 +41,25 @@ enum class FunctionID {
     setMeshQuads = 51,
     setMeshTetrahedron = 52,
     setMeshTetrahedra = 53,
-    setMeshAccessRegion = 54,
-    getMeshVerticesAndIDs = 55,
     
-    hasData = 60,
-    writeBlockVectorData = 61,
-    writeVectorData = 62,
-    writeBlockScalarData = 63,
-    writeScalarData = 64,
-    readBlockVectorData = 65,
-    readVectorData = 66,
-    readBlockScalarData = 67,
-    readScalarData = 68,
-    writeBlockVectorGradientData = 69,
-    writeVectorGradientData = 70,
-    writeBlockScalarGradientData = 71,
-    writeScalarGradientData = 72,
+    writeData = 60,
+    readData = 61,
+    requiresGradientDataFor = 62,
+    writeBlockVectorGradientData = 63,
+    setMeshAccessRegion = 64,
+    getMeshVerticesAndIDs = 65,
 };
 
 
 std::string convertToString(const matlab::data::Array& arr) {
     matlab::data::TypedArray<MATLABString> in1 = arr;
-    std::string solverName = in1[0];
-    return solverName;
+    std::string participantName = in1[0];
+    return participantName;
 }
 
 class MexFunction: public matlab::mex::Function {
 private:
-    SolverInterface* interface;
+    Participant* interface;
     ArrayFactory factory;
     bool constructed;
     std::shared_ptr<matlab::engine::MATLABEngine> matlabPtr = getEngine();
@@ -84,7 +77,7 @@ public:
         FunctionID functionID = static_cast<FunctionID>(static_cast<int>(functionIDArray[0]));
         
         // Abort if constructor was not called before, or if constructor 
-        // was called on an existing solverInterface
+        // was called on an existing participant
         if (functionID==FunctionID::_constructor_ && constructed) {
             myMexPrint("Constructor was called but interface is already constructed.");
             return;
@@ -103,11 +96,11 @@ public:
             // 60-79: Data Access
             case FunctionID::_constructor_:
             {
-                std::string solverName = convertToString(inputs[1]);
+                std::string participantName = convertToString(inputs[1]);
                 std::string configFileName = convertToString(inputs[2]);
                 const TypedArray<int32_t> procIndex = inputs[3];
                 const TypedArray<int32_t> procSize = inputs[4];
-                interface = new SolverInterface(solverName,configFileName,procIndex[0],procSize[0]);
+                interface = new Participant(participantName,configFileName,procIndex[0],procSize[0]);
                 constructed = true;
                 break;
             }
@@ -119,15 +112,13 @@ public:
             }
             case FunctionID::initialize:
             {
-                double dt = interface->initialize();
-                outputs[0] = factory.createArray<double>({1,1}, {dt});
+                interface->initialize();
                 break;
             }
             case FunctionID::advance:
             {
                 const TypedArray<double> dt_old = inputs[1];
-                double dt = interface->advance(dt_old[0]);
-                outputs[0] = factory.createArray<double>({1,1}, {dt});
+                interface->advance(dt_old[0]);
                 break;
             }
             case FunctionID::finalize:
@@ -136,9 +127,17 @@ public:
                 break;
             }
             
-            case FunctionID::getDimensions:
+            case FunctionID::getMeshDimensions:
             {
-                int dims = interface->getDimensions();
+                int dims = interface->getMeshDimensions();
+                outputs[0] = factory.createArray<uint8_t>({1,1}, {(uint8_t) dims});
+                break;
+            }
+            case FunctionID::getDataDimensions:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const std::string dataName = convertToString(inputs[2]);
+                int dims = interface->getDataDimensions(meshName, dataName);
                 outputs[0] = factory.createArray<uint8_t>({1,1}, {(uint8_t) dims});
                 break;
             }
@@ -152,6 +151,12 @@ public:
             {
                 bool result = interface->isTimeWindowComplete();
                 outputs[0] = factory.createArray<bool>({1,1}, {result});
+                break;
+            }
+            case FunctionID::getMaxTimeStepSize:
+            {
+                double result = interface->getMaxTimeStepSize();
+                outputs[0] = factory.createArray<double>({1,1}, {result});
                 break;
             }
             case FunctionID::requiresInitialData:
@@ -178,20 +183,28 @@ public:
                 bool output = interface->hasMesh(meshName);
                 outputs[0] = factory.createScalar<bool>(output);
                 break;
-            }            
+            }
+            case FunctionID::hasData:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const std::string dataName = convertToString(inputs[2]);
+                bool output = interface->hasData(meshName,dataName);
+                outputs[0] = factory.createScalar<bool>(output);
+                break;
+            }
+            case FunctionID::requiresMeshConnectivityFor:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                bool output = interface->requiresMeshConnectivityFor(meshName);
+                outputs[0] = factory.createScalar<bool>(output);
+                break;
+            }
             case FunctionID::setMeshVertex:
             {
                 const std::string meshName = convertToString(inputs[1]);
                 const TypedArray<double> position = inputs[2];
                 int id = interface->setMeshVertex(meshName,&*position.begin());
                 outputs[0] = factory.createScalar<int32_t>(id);
-                break;
-            }
-            case FunctionID::getMeshVertexSize:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                int size = interface->getMeshVertexSize(meshName);
-                outputs[0] = factory.createScalar<int32_t>(size);
                 break;
             }
             case FunctionID::setMeshVertices:
@@ -206,12 +219,27 @@ public:
                 outputs[0] = factory.createArrayFromBuffer<int32_t>({1,size[0]}, std::move(ids_ptr));
                 break;
             }
+            case FunctionID::getMeshVertexSize:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                int size = interface->getMeshVertexSize(meshName);
+                outputs[0] = factory.createScalar<int32_t>(size);
+                break;
+            }
             case FunctionID::setMeshEdge:
             {
                 const std::string meshName = convertToString(inputs[1]);
                 const TypedArray<int32_t> firstVertexID = inputs[2];
                 const TypedArray<int32_t> secondVertexID = inputs[3];
                 interface->setMeshEdge(meshName,firstVertexID[0],secondVertexID[0]);
+                break;
+            }
+            case FunctionID::setMeshEdges:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const TypedArray<int32_t> size = inputs[2];
+                const TypedArray<int32_t> vertices = inputs[3];
+                interface->setMeshEdges(meshName,size[0],&*vertices.begin());
                 break;
             }
             case FunctionID::setMeshTriangle:
@@ -223,6 +251,14 @@ public:
                 interface->setMeshTriangle(meshName,firstEdgeID[0],secondEdgeID[0],thirdEdgeID[0]);
                 break;
             }
+            case FunctionID::setMeshTriangles:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const TypedArray<int32_t> size = inputs[2];
+                const TypedArray<int32_t> vertices = inputs[3];
+                interface->setMeshTriangles(meshName,size[0],&*vertices.begin());
+                break;
+            }
             case FunctionID::setMeshQuad:
             {
                 const std::string meshName = convertToString(inputs[1]);
@@ -231,6 +267,73 @@ public:
                 const TypedArray<int32_t> thirdEdgeID = inputs[4];
                 const TypedArray<int32_t> fourthEdgeID = inputs[5];
                 interface->setMeshQuad(meshName,firstEdgeID[0],secondEdgeID[0],thirdEdgeID[0],fourthEdgeID[0]);
+                break;
+            }
+            case FunctionID::setMeshQuads:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const TypedArray<int32_t> size = inputs[2];
+                const TypedArray<int32_t> vertices = inputs[3];
+                interface->setMeshQuads(meshName,size[0],&*vertices.begin());
+                break;
+            }
+            case FunctionID::setMeshTetrahedron:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const TypedArray<int32_t> firstTriangleID = inputs[2];
+                const TypedArray<int32_t> secondTriangleID = inputs[3];
+                const TypedArray<int32_t> thirdTriangleID = inputs[4];
+                const TypedArray<int32_t> fourthTriangleID = inputs[5];
+                interface->setMeshTetrahedron(meshName,firstTriangleID[0],secondTriangleID[0],thirdTriangleID[0],fourthTriangleID[0]);
+                break;
+            }
+            case FunctionID::setMeshTetrahedra:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const TypedArray<int32_t> size = inputs[2];
+                const TypedArray<int32_t> vertices = inputs[3];
+                interface->setMeshTetrahedra(meshName,size[0],&*vertices.begin());
+                break;
+            }
+            case FunctionID::writeData:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const std::string dataName = convertToString(inputs[2]);
+                const TypedArray<int32_t> size = inputs[3];
+                const TypedArray<int32_t> vertexIDs = inputs[4];
+                const TypedArray<double> values = inputs[5];
+                interface->writeData(meshName,dataName,size[0],&*vertexIDs.begin(),&*values.begin());
+                break;
+            }
+            case FunctionID::readData:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const std::string dataName = convertToString(inputs[2]);
+                const TypedArray<int32_t> size = inputs[3];
+                const TypedArray<int32_t> vertexIDs = inputs[4];
+                size_t dim = interface->getDimensions();
+                buffer_ptr_t<double> values_ptr = factory.createBuffer<double>(size[0]*dim);
+                double* values = values_ptr.get();
+                interface->readData(meshName,dataName,size[0],&*vertexIDs.begin(),values);
+                outputs[0] = factory.createArrayFromBuffer<double>({dim,size[0]}, std::move(values_ptr));
+                break;
+            }
+            case FunctionID::requiresGradientDataForBlock:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const std::string dataName = convertToString(inputs[2]);
+                bool requiresGradientData = interface->requiresGradientDataForBlock(meshName,dataName);
+                outputs[0] = factory.createScalar<bool>(requiresGradientData);
+                break;
+            }
+            case FunctionID::writeBlockVectorGradientData:
+            {
+                const std::string meshName = convertToString(inputs[1]);
+                const std::string dataName = convertToString(inputs[2]);
+                const TypedArray<int32_t> size = inputs[3];
+                const TypedArray<int32_t> vertexIDs = inputs[4];
+                const TypedArray<double> gradientValues = inputs[5];
+                interface->writeBlockVectorGradientData(meshName,dataName, size[0], &*vertexIDs.begin(), &*gradientValues.begin());
                 break;
             }
             case FunctionID::setMeshAccessRegion:
@@ -253,147 +356,7 @@ public:
                 outputs[1] = factory.createArrayFromBuffer<int32_t>({1,size[0]}, std::move(ids_ptr));
                 break;
             } 
-            case FunctionID::hasData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                bool output = interface->hasData(meshName,dataName);
-                outputs[0] = factory.createScalar<bool>(output);
-                break;
-            }
-            case FunctionID::writeBlockVectorData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> size = inputs[3];
-                const TypedArray<int32_t> vertexIDs = inputs[4];
-                const TypedArray<double> values = inputs[5];
-                interface->writeBlockVectorData(meshName,dataName,size[0],&*vertexIDs.begin(),&*values.begin());
-                break;
-            }
-            case FunctionID::writeVectorData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> valueIndex = inputs[3];
-                const TypedArray<double> value = inputs[4];
-                interface->writeVectorData(meshName,dataName,valueIndex[0],&*value.begin());
-                break;
-            }
-            case FunctionID::writeBlockScalarData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> size = inputs[3];
-                const TypedArray<int32_t> vertexIDs = inputs[4];
-                const TypedArray<double> values = inputs[5];
-                interface->writeBlockScalarData(meshName,dataName,size[0],&*vertexIDs.begin(),&*values.begin());
-                break;
-            }
-            case FunctionID::writeScalarData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> valueIndex = inputs[3];
-                const TypedArray<double> value = inputs[4];
-                interface->writeScalarData(meshName,dataName,valueIndex[0],value[0]);
-                break;
-            }
-            case FunctionID::readBlockVectorData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> size = inputs[3];
-                const TypedArray<int32_t> vertexIDs = inputs[4];
-                size_t dim = interface->getDimensions();
-                buffer_ptr_t<double> values_ptr = factory.createBuffer<double>(size[0]*dim);
-                double* values = values_ptr.get();
-                interface->readBlockVectorData(meshName,dataName,size[0],&*vertexIDs.begin(),values);
-                outputs[0] = factory.createArrayFromBuffer<double>({dim,size[0]}, std::move(values_ptr));
-                break;
-            }
-            case FunctionID::readVectorData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> valueIndex = inputs[3];
-                size_t dim = interface->getDimensions();
-                buffer_ptr_t<double> value_ptr = factory.createBuffer<double>(dim);
-                double* value = value_ptr.get();
-                interface->readVectorData(meshName,dataName,valueIndex[0],value);
-                outputs[0] = factory.createArrayFromBuffer<double>({dim,1}, std::move(value_ptr));
-                break;
-            }
-            case FunctionID::readBlockScalarData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> size = std::move(inputs[3]);
-                const TypedArray<int32_t> valueIndices = std::move(inputs[4]);
-                const TypedArray<bool> transpose = std::move(inputs[5]);
-                size_t sizeA, sizeB;
-                if (transpose[0]) {
-                    sizeA = size[0];
-                    sizeB = 1;
-                }
-                else {
-                    sizeA = 1;
-                    sizeB = size[0];
-                }
-                buffer_ptr_t<double> values_ptr = factory.createBuffer<double>(size[0]);
-                double* values = values_ptr.get();
-                interface->readBlockScalarData(meshName,dataName,size[0],&*valueIndices.begin(),values);
-                outputs[0] = factory.createArrayFromBuffer<double>({sizeA,sizeB}, std::move(values_ptr));
-                break;
-            }
-            case FunctionID::readScalarData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> valueIndex = inputs[3];
-                double value;
-                interface->readScalarData(meshName,dataName,valueIndex[0],value);
-                outputs[0] = factory.createScalar<double>(value);
-                break;
-            }
-            case FunctionID::writeBlockVectorGradientData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> size = inputs[3];
-                const TypedArray<int32_t> vertexIDs = inputs[4];
-                const TypedArray<double> gradientValues = inputs[5];
-                interface->writeBlockVectorGradientData(meshName,dataName, size[0], &*vertexIDs.begin(), &*gradientValues.begin());
-                break;
-            }
-            case FunctionID::writeScalarGradientData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> vertexID = inputs[3];
-                const TypedArray<double> gradientValues = inputs[4];
-                interface->writeScalarGradientData(meshName,dataName, vertexID[0], &*gradientValues.begin());
-                break;
-            }
-            case FunctionID::writeVectorGradientData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> vertexID = inputs[3];
-                const TypedArray<double> gradientValues = inputs[4];
-                interface->writeVectorGradientData(meshName,dataName, vertexID[0], &*gradientValues.begin());
-                break;
-            }
-            case FunctionID::writeBlockScalarGradientData:
-            {
-                const std::string meshName = convertToString(inputs[1]);
-                const std::string dataName = convertToString(inputs[2]);
-                const TypedArray<int32_t> size = inputs[3];
-                const TypedArray<int32_t> vertexIDs = inputs[4];
-                const TypedArray<double> gradientValues = inputs[5];
-                interface->writeBlockScalarGradientData(meshName,dataName, size[0], &*vertexIDs.begin(), &*gradientValues.begin());
-                break;
-            }
+
             default:
                 myMexPrint("An unknown ID was passed.");
                 return;

--- a/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
+++ b/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
@@ -1,18 +1,18 @@
-classdef SolverInterfaceOOP < precice.SolverInterface
-    %SOLVERINTERFACE Matlab wrapper for the C++ SolverInterface
-    %   This class will serve as a gateway for the precice Solver Interface
+classdef ParticipantOOP < precice.Participant
+    %PARTICIPANT Matlab wrapper for the C++ Participant
+    %   This class will serve as a gateway for the precice Participant
     %   in C++. It has access to a private mex Function written in the new
-    %   MATLAB C++ API. Such a function is actually an instance of a C++ 
-    %   class that is stored internally by MATLAB. Whenever they are 
+    %   MATLAB C++ API. Such a function is actually an instance of a C++
+    %   class that is stored internally by MATLAB. Whenever they are
     %   "called", a subroutine of the object (operator ()) is invoked which
     %   then has access to the members of the class.
-    %   Hence, we can store the actual solver interface in this class and
+    %   Hence, we can store the actual participant in this class and
     %   access it by invoking the mex function.
     
     properties(Access=private)
         % Possible changes:
-        % - Allow the creation of multiple SolverInterfaces. For this, we
-        % should replace the interface pointer in the Gateway by a list of 
+        % - Allow the creation of multiple Participants. For this, we
+        % should replace the interface pointer in the Gateway by a list of
         % interface pointers and add an InterfaceID as property of this
         % class.
         
@@ -26,22 +26,22 @@ classdef SolverInterfaceOOP < precice.SolverInterface
     methods
         %% Construction
         % Constructor
-        function obj = SolverInterface(SolverName,configFileName,solverProcessIndex,solverProcessSize)
-            %SOLVERINTERFACE Construct an instance of this class
+        function obj = Participant(ParticipantName,configFileName,ProcessIndex,ProcessSize)
+            %PARTICIPANT Construct an instance of this class
             % Initialize the mex host
             obj.oMexHost = mexhost;
             obj.bMexHostRunning = true;
             
-            if (solverProcessIndex > 0 || solverProcessSize > 1)
-                error('Parallel runs are currently not supported with the MATLAB bindings.')    
+            if (ProcessIndex > 0 || ProcessSize > 1)
+                error('Parallel runs are currently not supported with the MATLAB bindings.')
             end
-            if ischar(SolverName)
-                SolverName = string(SolverName);
+            if ischar(ParticipantName)
+                ParticipantName = string(ParticipantName);
             end
             if ischar(configFileName)
                 configFileName = string(configFileName);
             end
-            feval(obj.oMexHost,"preciceGateway",uint8(0),SolverName,configFileName,int32(solverProcessIndex),int32(solverProcessSize));
+            feval(obj.oMexHost,"preciceGateway",uint8(0),ParticipantName,configFileName,int32(ProcessIndex),int32(ProcessSize));
         end
         
         % Destructor
@@ -53,13 +53,13 @@ classdef SolverInterfaceOOP < precice.SolverInterface
         
         %% Steering methods
         % initialize
-        function dt = initialize(obj)
-            dt = feval(obj.oMexHost,"preciceGateway",uint8(10));
+        function initialize(obj)
+            feval(obj.oMexHost,"preciceGateway",uint8(10));
         end
         
         % advance
-        function dt = advance(obj,dt)
-            dt = feval(obj.oMexHost,"preciceGateway",uint8(11),dt);
+        function advance(obj,dt)
+            feval(obj.oMexHost,"preciceGateway",uint8(11),dt);
         end
         
         % finalize
@@ -68,34 +68,53 @@ classdef SolverInterfaceOOP < precice.SolverInterface
         end
         
         %% Status queries
-        % getDimensions
-        function dims = getDimensions(obj)
-            dims = feval(obj.oMexHost,"preciceGateway",uint8(20));
+        % getMeshDimensions
+        function dims = getMeshDimensions(obj,meshName)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            dims = feval(obj.oMexHost,"preciceGateway",uint8(20),meshName);
+        end
+        
+        % getDataDimensions
+        function dims = getDataDimensions(obj,meshName,dataName)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            if ischar(dataName)
+                dataName = string(dataName);
+            end
+            dims = feval(obj.oMexHost,"preciceGateway",uint8(21),meshName,dataName);
         end
         
         % isCouplingOngoing
         function bool = isCouplingOngoing(obj)
-            bool = feval(obj.oMexHost,"preciceGateway",uint8(21));
+            bool = feval(obj.oMexHost,"preciceGateway",uint8(22));
         end
         
         % isTimestepComplete
         function bool = isTimeWindowComplete(obj)
-            bool = feval(obj.oMexHost,"preciceGateway",uint8(22));
+            bool = feval(obj.oMexHost,"preciceGateway",uint8(23));
+        end
+
+        % getMaxTimeStepSize
+        function dt = getMaxTimeStepSize(obj)
+            dt = feval(obj.oMexHost,"preciceGateway",uint8(24));
         end
 
         % requiresInitialData
         function bool = requiresInitialData(obj)
-            bool = feval(obj.oMexHost,"preciceGateway",uint8(23));
+            bool = feval(obj.oMexHost,"preciceGateway",uint8(25));
         end
 
         % requiresReadingCheckpoint
         function bool = requiresReadingCheckpoint(obj)
-            bool = feval(obj.oMexHost,"preciceGateway",uint8(24));
+            bool = feval(obj.oMexHost,"preciceGateway",uint8(26));
         end
 
         % requiresWritingCheckpoint
         function bool = requiresWritingCheckpoint(obj)
-            bool = feval(obj.oMexHost,"preciceGateway",uint8(25));
+            bool = feval(obj.oMexHost,"preciceGateway",uint8(26));
         end
 
         %% Mesh Access
@@ -107,12 +126,158 @@ classdef SolverInterfaceOOP < precice.SolverInterface
             bool = feval(obj.oMexHost,"preciceGateway",uint8(40),meshName);
         end
 
+        % hasData
+        function bool = hasData(obj,meshName,dataName)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            if ischar(dataName)
+                dataName = string(dataName);
+            end
+            bool = feval(obj.oMexHost,"preciceGateway",uint8(41),meshName,dataName);
+        end
+
         % requiresMeshConnectivityFor
         function bool = requiresMeshConnectivityFor(obj,meshName)
             if ischar(meshName)
                 meshName = string(meshName);
             end
-            bool = feval(obj.oMexHost,"preciceGateway",uint8(41),meshName);
+            bool = feval(obj.oMexHost,"preciceGateway",uint8(42),meshName);
+        end
+        
+        % setMeshVertex
+        function vertexId = setMeshVertex(obj,meshName,position)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            vertexId = feval(obj.oMexHost,"preciceGateway",uint8(43),meshName,position);
+        end
+        
+        % setMeshVertices
+        function vertexIds = setMeshVertices(obj,meshName,positions)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            obj.checkDimensions(size(positions, 1), obj.getDimensions())
+            inSize = size(positions,2);
+            vertexIds = feval(obj.oMexHost,"preciceGateway",uint8(44),meshName,int32(inSize),positions);
+        end
+
+        % getMeshVertexSize
+        function vertexId = getMeshVertexSize(obj,meshName)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            vertexId = feval(obj.oMexHost,"preciceGateway",uint8(45),meshName);
+        end
+        
+        % setMeshEdge
+        function edgeID = setMeshEdge(obj, meshName, firstVertexID, secondVertexID)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            edgeID = feval(obj.oMexHost,"preciceGateway",uint8(46),meshName,int32(firstVertexID),int32(secondVertexID));
+        end
+
+        % setMeshEdges
+        function edgeIDs = setMeshEdges(obj, meshName, vertices)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            obj.checkDimensions(size(vertices,1), 2)
+            inSize = size(vertices,2);
+            edgeIDs = feval(obj.oMexHost,"preciceGateway",uint8(47),meshName,int32(inSize),vertices);
+        end
+
+        % setMeshTriangle
+        function setMeshTriangle(obj, meshName, firstVertexID, secondVertexID, thirdVertexID)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            feval(obj.oMexHost,"preciceGateway",uint8(48),meshName,int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID));
+        end
+
+        % setMeshTriangles
+        function setMeshTriangles(obj, meshName, vertices)
+            obj.checkDimensions(size(vertices,1), 3)
+            inSize = size(vertices,2);
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            feval(obj.oMexHost,"preciceGateway",uint8(49),meshName,int32(inSize),vertices);
+        end
+        
+        % setMeshQuad
+        function setMeshQuad(obj, meshName, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            feval(obj.oMexHost,"preciceGateway",uint8(50),meshName,int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
+        end
+
+        % setMeshQuads
+        function setMeshQuads(obj, meshName, vertices)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            obj.checkDimensions(size(vertices,1), 4)
+            inSize = size(vertices,2);
+            feval(obj.oMexHost,"preciceGateway",uint8(51),meshName,int32(inSize),vertices);
+        end
+
+        % setMeshTetrahedron
+        function setMeshTetrahedron(obj, meshName, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID)
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            feval(obj.oMexHost,"preciceGateway",uint8(52),meshName,int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
+        end
+
+        % setMeshTetrahedra
+        function setMeshTetrahedra(obj, meshName, vertices)
+            obj.checkDimensions(size(vertices,1), 4)
+            inSize = size(vertices,2);
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            feval(obj.oMexHost,"preciceGateway",uint8(53),meshName,int32(inSize),vertices);
+        end
+
+
+        %% Data Access
+        % writeData
+        function writeData(obj,meshName,dataName,valueIndices,values)
+            if ~isa(valueIndices,'int32')
+                warning('valueIndices should be allocated as int32 to prevent copying.');
+                valueIndices = int32(valueIndices);
+            end
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            if ischar(dataName)
+                dataName = string(dataName);
+            end
+
+            inSize = length(valueIndices);
+            obj.checkDimensions(size(values, 2), inSize)
+            obj.checkDimensions(size(values, 1), obj.getDimensions())
+            feval(obj.oMexHost,"preciceGateway",uint8(60),meshName,dataName,int32(inSize),valueIndices,values);
+        end
+        
+        % readData
+        function values = readData(obj,meshName,dataName,valueIndices)
+            if ~isa(valueIndices,'int32')
+                warning('valueIndices should be allocated as int32 to prevent copying.');
+                valueIndices = int32(valueIndices);
+            end
+            if ischar(meshName)
+                meshName = string(meshName);
+            end
+            if ischar(dataName)
+                dataName = string(dataName);
+            end
+            inSize = length(valueIndices);
+            values = feval(obj.oMexHost,"preciceGateway",uint8(61),meshName,dataName,int32(inSize),valueIndices);
         end
 
         % requiresGradientDataFor
@@ -123,252 +288,9 @@ classdef SolverInterfaceOOP < precice.SolverInterface
             if ischar(dataName)
                 dataName = string(dataName);
             end
-            bool = feval(obj.oMexHost,"preciceGateway",uint8(42),meshName,dataName);
-        end
-        
-        % setMeshVertex
-        function vertexId = setMeshVertex(obj,meshName,position)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            vertexId = feval(obj.oMexHost,"preciceGateway",uint8(43),meshName,position);
+            bool = feval(obj.oMexHost,"preciceGateway",uint8(62),meshName,dataName);
         end
 
-        % getMeshVertexSize
-        function vertexId = getMeshVertexSize(obj,meshName)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            vertexId = feval(obj.oMexHost,"preciceGateway",uint8(44),meshName);
-        end
-        
-        % setMeshVertices
-        function vertexIds = setMeshVertices(obj,meshName,positions)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            obj.checkDimensions(size(positions, 1), obj.getDimensions())
-            inSize = size(positions,2);
-            vertexIds = feval(obj.oMexHost,"preciceGateway",uint8(45),meshName,int32(inSize),positions);
-        end
-        
-        % setMeshEdge
-        function edgeID = setMeshEdge(obj, meshName, firstVertexID, secondVertexID)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            edgeID = feval(obj.oMexHost,"preciceGateway",uint8(46),meshName,int32(firstVertexID),int32(secondVertexID));
-        end
-
-        % setMeshEdges
-        function edgeIDs = setMeshEdges(obj, meshName, vertices)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            obj.checkDimensions(size(vertices,1), 2)
-            inSize = size(vertices,2);
-            edgeIDs = feval(obj.oMexHost,"preciceGateway",uint8(47),meshName,int32(inSize),vertices);
-        end
-
-        % setMeshTriangle
-        function setMeshTriangle(obj, meshName, firstVertexID, secondVertexID, thirdVertexID)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            feval(obj.oMexHost,"preciceGateway",uint8(48),meshName,int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID));
-        end
-
-        % setMeshTriangles
-        function setMeshTriangles(obj, meshName, vertices)
-            obj.checkDimensions(size(vertices,1), 3)
-            inSize = size(vertices,2);
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            feval(obj.oMexHost,"preciceGateway",uint8(49),meshName,int32(inSize),vertices);
-        end
-        
-        % setMeshQuad
-        function setMeshQuad(obj, meshName, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            feval(obj.oMexHost,"preciceGateway",uint8(50),meshName,int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
-        end
-
-        % setMeshQuads
-        function setMeshQuads(obj, meshName, vertices)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            obj.checkDimensions(size(vertices,1), 4)
-            inSize = size(vertices,2);
-            feval(obj.oMexHost,"preciceGateway",uint8(51),meshName,int32(inSize),edges);
-        end
-
-        % setMeshTetrahedron
-        function setMeshTetrahedron(obj, meshName, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            feval(obj.oMexHost,"preciceGateway",uint8(52),meshName,int32(firstVertexID),int32(secondVertexID),int32(thirdVertexID),int32(fourthVertexID));
-        end
-
-        % setMeshTetrahedra
-        function setMeshTetrahedra(obj, meshName, vertices)
-            obj.checkDimensions(size(vertices,1), 4)
-            inSize = size(vertices,2);
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            feval(obj.oMexHost,"preciceGateway",uint8(53),meshName,int32(inSize),vertices);
-        end
-        
-        % setMeshAccessRegion
-        function setMeshAccessRegion(meshName, boundingBox)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            feval(obj.oMexHost,"preciceGateway",uint8(54),meshName,boundingBox);
-        end
-
-        % getMeshVerticesAndIDs
-        function [vertices, outIDs] = getMeshVerticesAndIDs(meshName)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            inSize = getMeshVertexSize(meshName);
-            [vertices,outIDs] = feval(obj.oMexHost,"preciceGateway",uint8(55),meshName,int32(inSize));
-        end
-
-        %% Data Access
-        % hasData
-        function bool = hasData(obj,meshName,dataName)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName);
-            end
-            bool = feval(obj.oMexHost,"preciceGateway",uint8(60),dataName,meshName);
-        end
-        
-        % writeBlockVectorData
-        function writeBlockVectorData(obj,meshName,dataName,valueIndices,values)
-            if ~isa(valueIndices,'int32')
-                warning('valueIndices should be allocated as int32 to prevent copying.');
-                valueIndices = int32(valueIndices);
-            end
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-
-            inSize = length(valueIndices);
-            obj.checkDimensions(size(values, 2), inSize)
-            obj.checkDimensions(size(values, 1), obj.getDimensions())
-            feval(obj.oMexHost,"preciceGateway",uint8(61),meshName,dataName,int32(inSize),valueIndices,values);
-        end
-        
-        % writeVectorData
-        function writeVectorData(obj,meshName,dataName,valueIndex,value)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-            feval(obj.oMexHost,"preciceGateway",uint8(62),meshName,dataName,int32(valueIndex),value);
-        end
-        
-        % writeBlockScalarData
-        function writeBlockScalarData(obj,meshName,dataName,valueIndices,values)
-            if ~isa(valueIndices,'int32')
-                warning('valueIndices should be allocated as int32 to prevent copying.');
-                valueIndices = int32(valueIndices);
-            end
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-            inSize = length(valueIndices);
-            assert(inSize == length(values), 'valueIndices and values should must have the same length');
-            feval(obj.oMexHost,"preciceGateway",uint8(63),meshName,dataName,int32(inSize),valueIndices,values);
-        end
-        
-        % writeScalarData
-        function writeScalarData(obj,meshName,dataName,valueIndex,value)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-            feval(obj.oMexHost,"preciceGateway",uint8(64),meshName,dataName,int32(valueIndex),value);
-        end
-        
-        % readBlockVectorData
-        function values = readBlockVectorData(obj,meshName,dataName,valueIndices)
-            if ~isa(valueIndices,'int32')
-                warning('valueIndices should be allocated as int32 to prevent copying.');
-                valueIndices = int32(valueIndices);
-            end
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-            inSize = length(valueIndices);
-            values = feval(obj.oMexHost,"preciceGateway",uint8(65),meshName,dataName,int32(inSize),valueIndices);
-        end
-        
-        % readVectorData
-        function value = readVectorData(obj,meshName,dataName,valueIndex)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-            value = feval(obj.oMexHost,"preciceGateway",uint8(66),meshName,dataName,int32(valueIndex));
-        end
-        
-        % readBlockScalarData
-        function values = readBlockScalarData(obj,meshName,dataName,valueIndices,transpose)
-            if nargin<4
-                transpose=false;
-            end
-            if ~isa(valueIndices,'int32')
-                warning('valueIndices should be allocated as int32 to prevent copying.');
-                valueIndices = int32(valueIndices);
-            end
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-            inSize = length(valueIndices);
-            values = feval(obj.oMexHost,"preciceGateway",uint8(67),meshName,dataName,int32(inSize),valueIndices,transpose);
-        end
-        
-        % readScalarData
-        function value = readScalarData(obj,meshName,dataName,valueIndex)
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-            value = feval(obj.oMexHost,"preciceGateway",uint8(68),meshName,dataName,int32(valueIndex));
-        end
-
-        %% Data Access
         % writeBlockVectorGradientData
         function writeBlockVectorGradientData(obj, meshName, dataName, valueIndices, gradientValues)
             if ~isa(valueIndices, 'int32')
@@ -376,59 +298,32 @@ classdef SolverInterfaceOOP < precice.SolverInterface
                 valueIndices = int32(valueIndices);
             end
             if ischar(meshName)
-                meshName = string(meshName)
+                meshName = string(meshName);
             end
             if ischar(dataName)
-                dataName = string(dataName)
+                dataName = string(dataName);
             end
             inSize = length(valueIndices);
             obj.checkDimensions(size(gradientValues, 2), inSize)
             obj.checkDimensions(size(gradientValues, 1), obj.getDimensions() * obj.getDimensions())
-            feval(obj.oMexHost, "preciceGateway", uint8(69), meshName,dataName, int32(inSize), valueIndices, gradientValues);
+            feval(obj.oMexHost, "preciceGateway", uint8(63), meshName,dataName, int32(inSize), valueIndices, gradientValues);
         end
 
-        % writeVectorGradientData
-        function writeVectorGradientData(obj, meshName, dataName, valueIndex, gradientValues)
-            obj.checkDimensions(size(gradientValues, 1), obj.getDimensions() * obj.getDimensions())
+        % setMeshAccessRegion
+        function setMeshAccessRegion(meshName, boundingBox)
             if ischar(meshName)
-                meshName = string(meshName)
+                meshName = string(meshName);
             end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-            feval(obj.oMexHost, "preciceGateway", uint8(70), meshName,dataName, int32(valueIndex), gradientValues);
+            feval(obj.oMexHost,"preciceGateway",uint8(64),meshName,boundingBox);
         end
 
-        % writeBlockScalarGradientData
-        function writeBlockScalarGradientData(obj, meshName, dataName, valueIndices, gradientValues)
-
-            if ~isa(valueIndices, 'int32')
-                warning('valueIndices should be allocated as int32 to prevent copying.');
-                valueIndices = int32(valueIndices);
-            end
+        % getMeshVerticesAndIDs
+        function [vertices, outIDs] = getMeshVerticesAndIDs(meshName)
             if ischar(meshName)
-                meshName = string(meshName)
+                meshName = string(meshName);
             end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-
-            inSize = length(valueIndices);
-            obj.checkDimensions(size(gradientValues, 2), inSize)
-            obj.checkDimensions(size(gradientValues, 1), obj.getDimensions())
-            feval(obj.oMexHost, "preciceGateway", uint8(71), meshName,dataName, int32(inSize), valueIndices, gradientValues);
-        end
-
-        % writeScalarGradientData
-        function writeScalarGradientData(obj, meshName, dataName, valueIndex, gradientValues)
-            obj.checkDimensions(size(gradientValues, 1), obj.getDimensions())
-            if ischar(meshName)
-                meshName = string(meshName)
-            end
-            if ischar(dataName)
-                dataName = string(dataName)
-            end
-            feval(obj.oMexHost, "preciceGateway", uint8(72), meshName,dataName, int32(valueIndex), gradientValues);
+            inSize = getMeshVertexSize(meshName);
+            [vertices,outIDs] = feval(obj.oMexHost,"preciceGateway",uint8(65),meshName,int32(inSize));
         end
 
         %% Helper functions

--- a/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
+++ b/+precice/@SolverInterfaceOOP/SolverInterfaceOOP.m
@@ -92,7 +92,7 @@ classdef ParticipantOOP < precice.Participant
             bool = feval(obj.oMexHost,"preciceGateway",uint8(22));
         end
         
-        % isTimestepComplete
+        % isTimeWindowComplete
         function bool = isTimeWindowComplete(obj)
             bool = feval(obj.oMexHost,"preciceGateway",uint8(23));
         end
@@ -200,11 +200,10 @@ classdef ParticipantOOP < precice.Participant
         % setMeshTriangles
         function setMeshTriangles(obj, meshName, vertices)
             obj.checkDimensions(size(vertices,1), 3)
-            inSize = size(vertices,2);
             if ischar(meshName)
                 meshName = string(meshName);
             end
-            feval(obj.oMexHost,"preciceGateway",uint8(49),meshName,int32(inSize),vertices);
+            feval(obj.oMexHost,"preciceGateway",uint8(49),meshName,vertices);
         end
         
         % setMeshQuad
@@ -221,8 +220,7 @@ classdef ParticipantOOP < precice.Participant
                 meshName = string(meshName);
             end
             obj.checkDimensions(size(vertices,1), 4)
-            inSize = size(vertices,2);
-            feval(obj.oMexHost,"preciceGateway",uint8(51),meshName,int32(inSize),vertices);
+            feval(obj.oMexHost,"preciceGateway",uint8(51),meshName,vertices);
         end
 
         % setMeshTetrahedron
@@ -236,11 +234,10 @@ classdef ParticipantOOP < precice.Participant
         % setMeshTetrahedra
         function setMeshTetrahedra(obj, meshName, vertices)
             obj.checkDimensions(size(vertices,1), 4)
-            inSize = size(vertices,2);
             if ischar(meshName)
                 meshName = string(meshName);
             end
-            feval(obj.oMexHost,"preciceGateway",uint8(53),meshName,int32(inSize),vertices);
+            feval(obj.oMexHost,"preciceGateway",uint8(53),meshName,vertices);
         end
 
 
@@ -258,14 +255,13 @@ classdef ParticipantOOP < precice.Participant
                 dataName = string(dataName);
             end
 
-            inSize = length(valueIndices);
             obj.checkDimensions(size(values, 2), inSize)
             obj.checkDimensions(size(values, 1), obj.getDimensions())
-            feval(obj.oMexHost,"preciceGateway",uint8(60),meshName,dataName,int32(inSize),valueIndices,values);
+            feval(obj.oMexHost,"preciceGateway",uint8(60),meshName,dataName,valueIndices,values);
         end
         
         % readData
-        function values = readData(obj,meshName,dataName,valueIndices)
+        function values = readData(obj,meshName,dataName,valueIndices,relativeReadTime)
             if ~isa(valueIndices,'int32')
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
@@ -277,7 +273,7 @@ classdef ParticipantOOP < precice.Participant
                 dataName = string(dataName);
             end
             inSize = length(valueIndices);
-            values = feval(obj.oMexHost,"preciceGateway",uint8(61),meshName,dataName,int32(inSize),valueIndices);
+            values = feval(obj.oMexHost,"preciceGateway",uint8(61),meshName,dataName,int32(inSize),valueIndices,relativeReadTime);
         end
 
         % requiresGradientDataFor
@@ -291,8 +287,8 @@ classdef ParticipantOOP < precice.Participant
             bool = feval(obj.oMexHost,"preciceGateway",uint8(62),meshName,dataName);
         end
 
-        % writeBlockVectorGradientData
-        function writeBlockVectorGradientData(obj, meshName, dataName, valueIndices, gradientValues)
+        % writeGradientData
+        function writeGradientData(obj, meshName, dataName, valueIndices, gradientValues)
             if ~isa(valueIndices, 'int32')
                 warning('valueIndices should be allocated as int32 to prevent copying.');
                 valueIndices = int32(valueIndices);
@@ -303,10 +299,9 @@ classdef ParticipantOOP < precice.Participant
             if ischar(dataName)
                 dataName = string(dataName);
             end
-            inSize = length(valueIndices);
             obj.checkDimensions(size(gradientValues, 2), inSize)
             obj.checkDimensions(size(gradientValues, 1), obj.getDimensions() * obj.getDimensions())
-            feval(obj.oMexHost, "preciceGateway", uint8(63), meshName,dataName, int32(inSize), valueIndices, gradientValues);
+            feval(obj.oMexHost, "preciceGateway", uint8(63),meshName,dataName,valueIndices,gradientValues);
         end
 
         % setMeshAccessRegion

--- a/solverdummy/precice-config.xml
+++ b/solverdummy/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="3">
   <log>
     <sink
       type="stream"
@@ -9,53 +9,51 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
-    <data:vector name="dataOne" />
-    <data:vector name="dataTwo" />
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
 
-    <mesh name="MeshOne">
-      <use-data name="dataOne" />
-      <use-data name="dataTwo" />
-    </mesh>
+  <mesh name="SolverOne-Mesh">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
 
-    <mesh name="MeshTwo">
-      <use-data name="dataOne" />
-      <use-data name="dataTwo" />
-    </mesh>
+  <mesh name="SolverTwo-Mesh">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
 
-    <participant name="SolverOne">
-      <provide-mesh name="MeshOne"/>
-      <write-data name="dataOne" mesh="MeshOne" />
-      <read-data name="dataTwo" mesh="MeshOne" />
-    </participant>
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+  </participant>
 
-    <participant name="SolverTwo">
-      <receive-mesh name="MeshOne" from="SolverOne" />
-      <provide-mesh name="MeshTwo"/>
-      <mapping:nearest-neighbor
-        direction="write"
-        from="MeshTwo"
-        to="MeshOne"
-        constraint="conservative" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="MeshOne"
-        to="MeshTwo"
-        constraint="consistent" />
-      <write-data name="dataTwo" mesh="MeshTwo" />
-      <read-data name="dataOne" mesh="MeshTwo" />
-    </participant>
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
 
-    <m2n:sockets from="SolverOne" to="SolverTwo" />
+  <m2n:sockets from="SolverOne" to="SolverTwo" />
 
-    <coupling-scheme:serial-implicit>
-      <participants first="SolverOne" second="SolverTwo" />
-      <max-time-windows value="2" />
-      <time-window-size value="1.0" />
-      <max-iterations value="2" />
-      <min-iteration-convergence-measure min-iterations="5" data="dataOne" mesh="MeshOne" />
-      <exchange data="dataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-      <exchange data="dataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <max-iterations value="2" />
+    <min-iteration-convergence-measure min-iterations="5" data="Data-One" mesh="SolverOne-Mesh" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/tutorial/explicit/Solver_U.m
+++ b/tutorial/explicit/Solver_U.m
@@ -1,7 +1,7 @@
 clear; close all; clc;
 
 % Initialize and configure preCICE
-interface = precice.SolverInterface("SolverU", "precice-config.xml", 0, 1);
+interface = precice.Participant("ParticipantU", "precice-config.xml", 0, 1);
 
 % Geometry IDs. As it is a 0-D simulation, only one vertex is necessary.
 meshName = "MeshU";
@@ -27,22 +27,24 @@ f_U = @(t, U, I) -I/C;      % Time derivative of U
 
 % Initialize simulation
 if interface.requiresInitialData()
-    interface.writeScalarData(meshName, DataNameU, vertex_ID, U0);
+    interface.writeData(meshName, DataNameU, vertex_ID, U0);
 end
-dt = interface.initialize();
+interface.initialize();
 
 % Start simulation
 t = t0 + dt;
-while t < t_max;
+while t < t_max
 
     % Make simulation step
     [t_ode, U_ode] = ode45(@(t, y) f_U(t, y, I0), [t0 t], U0);
     U0 = U_ode(end);
 
     % Exchange data
-    interface.writeScalarData(meshName, DataNameU, vertex_ID, U0);
-    dt = interface.advance(dt);
-    I0 = interface.readScalarData(meshName, DataNameI, vertex_ID);
+    interface.writeData(meshName, DataNameU, vertex_ID, U0);
+    interface.advance(dt);
+
+    dt = interface.getMaxTimeStepSize();
+    I0 = interface.readData(meshName, DataNameI, vertex_ID, dt);
 
     % Finish time step
     t0 = t;

--- a/tutorial/explicit/precice-config.xml
+++ b/tutorial/explicit/precice-config.xml
@@ -1,54 +1,51 @@
 <?xml version="1.0"?>
 
-<precice-configuration>
+<precice-configuration dimensions="2">
 
-  <solver-interface dimensions="2" >
-   
-    <data:scalar name="I"  />
-    <data:scalar name="U"  />
+  <data:scalar name="I"  />
+  <data:scalar name="U"  />
 
-    <mesh name="MeshI">
-      <use-data name="I" />
-      <use-data name="U" />
-    </mesh>
+  <mesh name="MeshI">
+    <use-data name="I" />
+    <use-data name="U" />
+  </mesh>
 
-    <mesh name="MeshU">
-      <use-data name="U" />
-      <use-data name="I" />
-    </mesh>
+  <mesh name="MeshU">
+    <use-data name="U" />
+    <use-data name="I" />
+  </mesh>
 
-    <participant name="SolverI">
-      <provide-mesh name="MeshI"/>
-      <receive-mesh name="MeshU" from="SolverU"/>
-      <write-data name="I"     mesh="MeshI" />
-      <read-data  name="U" mesh="MeshI" />
-      <mapping:nearest-neighbor
-        direction="write" from="MeshI" to="MeshU" constraint="consistent"/>
-      <mapping:nearest-neighbor
-        direction="read" from="MeshU" to="MeshI" constraint="consistent"/>
-    </participant>
+  <participant name="ParticipantI">
+    <provide-mesh name="MeshI"/>
+    <receive-mesh name="MeshU" from="ParticipantU"/>
+    <write-data name="I"     mesh="MeshI" />
+    <read-data  name="U" mesh="MeshI" />
+    <mapping:nearest-neighbor
+      direction="write" from="MeshI" to="MeshU" constraint="consistent"/>
+    <mapping:nearest-neighbor
+      direction="read" from="MeshU" to="MeshI" constraint="consistent"/>
+  </participant>
 
-    <participant name="SolverU">
-      <provide-mesh name="MeshU"/>
-      <receive-mesh name="MeshI" from="SolverI"/>
-      <write-data name="U"     mesh="MeshU" />
-      <read-data  name="I" mesh="MeshU" />
-      <mapping:nearest-neighbor
-        direction="write" from="MeshU" to="MeshI" constraint="consistent"/>
-      <mapping:nearest-neighbor
-        direction="read" from="MeshI" to="MeshU" constraint="consistent"/>
-    </participant>
+  <participant name="ParticipantU">
+    <provide-mesh name="MeshU"/>
+    <receive-mesh name="MeshI" from="ParticipantI"/>
+    <write-data name="U"     mesh="MeshU" />
+    <read-data  name="I" mesh="MeshU" />
+    <mapping:nearest-neighbor
+      direction="write" from="MeshU" to="MeshI" constraint="consistent"/>
+    <mapping:nearest-neighbor
+      direction="read" from="MeshI" to="MeshU" constraint="consistent"/>
+  </participant>
 
-    <m2n:sockets from="SolverI" to="SolverU"/>
+  <m2n:sockets from="ParticipantI" to="ParticipantU"/>
+  
+  <coupling-scheme:serial-explicit>
+    <participants first="ParticipantI" second="ParticipantU" /> 
+    <max-time-windows value="1000" />
+    <time-window-size value="0.01" />
+    <exchange data="I" mesh="MeshI" from="ParticipantI" to="ParticipantU"/>
+    <exchange data="U" mesh="MeshU" from="ParticipantU" to="ParticipantI"/>
+  </coupling-scheme:serial-explicit>
     
-    <coupling-scheme:serial-explicit>
-      <participants first="SolverI" second="SolverU" /> 
-      <max-time-windows value="1000" />
-      <time-window-size value="0.01" />
-      <exchange data="I" mesh="MeshI" from="SolverI" to="SolverU"/>
-      <exchange data="U" mesh="MeshU" from="SolverU" to="SolverI"/>
-    </coupling-scheme:serial-explicit>
-    
-  </solver-interface>
-
 </precice-configuration>
+  

--- a/tutorial/implicit/precice-config.xml
+++ b/tutorial/implicit/precice-config.xml
@@ -1,56 +1,52 @@
 <?xml version="1.0"?>
 
-<precice-configuration>
+<precice-configuration dimensions="2">
 
-  <solver-interface dimensions="2" >
-   
-    <data:scalar name="I"  />
-    <data:scalar name="U"  />
+  <data:scalar name="I"  />
+  <data:scalar name="U"  />
 
-    <mesh name="MeshI">
-      <use-data name="I" />
-      <use-data name="U" />
-    </mesh>
+  <mesh name="MeshI">
+    <use-data name="I" />
+    <use-data name="U" />
+  </mesh>
 
-    <mesh name="MeshU">
-      <use-data name="U" />
-      <use-data name="I" />
-    </mesh>
+  <mesh name="MeshU">
+    <use-data name="U" />
+    <use-data name="I" />
+  </mesh>
 
-    <participant name="SolverI">
-      <provide-mesh name="MeshI" />
-      <receive-mesh name="MeshU" from="SolverU"/>
-      <write-data name="I"     mesh="MeshI" />
-      <read-data  name="U" mesh="MeshI" />
-      <mapping:nearest-neighbor
-        direction="write" from="MeshI" to="MeshU" constraint="consistent"/>
-      <mapping:nearest-neighbor
-        direction="read" from="MeshU" to="MeshI" constraint="consistent"/>
-    </participant>
+  <participant name="ParticipantI">
+    <provide-mesh name="MeshI" />
+    <receive-mesh name="MeshU" from="ParticipantU"/>
+    <write-data name="I"     mesh="MeshI" />
+    <read-data  name="U" mesh="MeshI" />
+    <mapping:nearest-neighbor
+      direction="write" from="MeshI" to="MeshU" constraint="consistent"/>
+    <mapping:nearest-neighbor
+      direction="read" from="MeshU" to="MeshI" constraint="consistent"/>
+  </participant>
 
-    <participant name="SolverU">
-      <provide-mesh name="MeshU" />
-      <receive-mesh name="MeshI" from="SolverI"/>
-      <write-data name="U"     mesh="MeshU" />
-      <read-data  name="I" mesh="MeshU" />
-      <mapping:nearest-neighbor
-        direction="write" from="MeshU" to="MeshI" constraint="consistent"/>
-      <mapping:nearest-neighbor
-        direction="read" from="MeshI" to="MeshU" constraint="consistent"/>
-    </participant>
+  <participant name="ParticipantU">
+    <provide-mesh name="MeshU" />
+    <receive-mesh name="MeshI" from="ParticipantI"/>
+    <write-data name="U"     mesh="MeshU" />
+    <read-data  name="I" mesh="MeshU" />
+    <mapping:nearest-neighbor
+      direction="write" from="MeshU" to="MeshI" constraint="consistent"/>
+    <mapping:nearest-neighbor
+      direction="read" from="MeshI" to="MeshU" constraint="consistent"/>
+  </participant>
 
-    <m2n:sockets from="SolverI" to="SolverU"/>
-    
-    <coupling-scheme:serial-implicit> 
-      <participants first="SolverI" second="SolverU" /> 
-      <max-time-windows value="1000" />
-      <time-window-size value="0.01" />
-      <max-iterations value="3" />
-      <min-iteration-convergence-measure min-iterations="5" data="I" mesh="MeshI"/>
-      <exchange data="I" mesh="MeshI" from="SolverI" to="SolverU"/>
-      <exchange data="U" mesh="MeshU" from="SolverU" to="SolverI"/>
-    </coupling-scheme:serial-implicit>     
-
-  </solver-interface>
+  <m2n:sockets from="ParticipantI" to="ParticipantU"/>
+  
+  <coupling-scheme:serial-implicit> 
+    <participants first="ParticipantI" second="ParticipantU" /> 
+    <max-time-windows value="1000" />
+    <time-window-size value="0.01" />
+    <max-iterations value="3" />
+    <min-iteration-convergence-measure min-iterations="5" data="I" mesh="MeshI"/>
+    <exchange data="I" mesh="MeshI" from="ParticipantI" to="ParticipantU"/>
+    <exchange data="U" mesh="MeshU" from="ParticipantU" to="ParticipantI"/>
+  </coupling-scheme:serial-implicit>     
 
 </precice-configuration>


### PR DESCRIPTION
This PR syncs the matlab bindings to the c++ API of `precice:develop`

One notable thing is that all functions that return something have to give the size as an input argument internally.
At least from my c++ understanding, eg. `readData` has to have the size as an input argument in the c++ preCICE Gateway. This does not affect the user, ie the user only gives `interface.readData(meshName,dataName,valueIndices,relativeReadTime)` and we get the size from `valueIndices`.