### PR TITLE
Change branches to run tests on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,14 @@
 name: 'Test MATLAB bindings'
 
-on: [push,pull_request]
+on: 
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - "*"
+
 jobs:
   test-solverdummies:
     name: Test MATLAB solverdummmies


### PR DESCRIPTION
This PR changes on which branches the tests are being run. When its "*" the tests are run twice for each PR. Therefore only testing on each push for develop and main is preferred.
This is the same change as discussed in https://github.com/precice/micro-manager/pull/37