### PR TITLE
Update MATLAB versions to be tested to the last three release versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,12 @@ jobs:
       matrix:
         include:
         - release: latest
+        - release: R2023b
+        - release: R2023a
         - release: R2022b
         - release: R2022a
         - release: R2021b
         # - release: R2021a # throws an error: https://github.com/precice/matlab-bindings/pull/42
-        - release: R2020b
-        - release: R2020a
     steps:
 
       - name: install precice
@@ -60,12 +60,12 @@ jobs:
       matrix:
         include:
         - release: latest
+        - release: R2023b
+        - release: R2023a
         - release: R2022b
         - release: R2022a
         - release: R2021b
         # - release: R2021a
-        - release: R2020b
-        - release: R2020a
     steps:
 
       - name: install precice

--- a/Contents.m
+++ b/Contents.m
@@ -1,5 +1,5 @@
 % MATLAB-bindings for coupling library preCICE
-% Version 2.5.0.0 (R2021b, R2021a, R2020b, R2020a) 11-Aug-2022
+% Version 2.5.0.0 (R2023b, R2023a, R2022b, R2022a, R2021b) 05-Feb-2024
 %
 % Files
 %   getVersionInformation - 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Note that the first three digits of the version number of the bindings indicate 
 
 ## Requirements
 
-MATLAB R2018a or later is required. The bindings are tested on R2021b, R2021a, R2020b, R2020a.
+MATLAB R2018a or later is required. The bindings are actively tested on versions R2023b, R2023a, R2022b, R2022a, and R2021b.
 
 ## Restrictions
 


### PR DESCRIPTION
Both *a* and *b* variants of the last three releases are tested (except for R2021a, due to a know problem).