### PR TITLE
Release v3.1.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install precice
         uses: precice/setup-precice-action@main
         with:
-          precice-version: 'v3.0.0'
+          precice-version: 'v3.1.0'
 
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1

--- a/Contents.m
+++ b/Contents.m
@@ -1,5 +1,5 @@
 % MATLAB-bindings for coupling library preCICE
-% Version 3.0.0.0 (R2023b, R2023a, R2022b, R2022a, R2021b) 05-Feb-2024
+% Version 3.1.0.0 (R2023b, R2023a, R2022b, R2022a, R2021b) 08-Apr-2024
 %
 % Files
 %   getVersionInformation - 


### PR DESCRIPTION
Compatibility release for preCICE [v3.1.0](https://github.com/precice/precice/releases/tag/v3.1.0)