### PR TITLE
I 52

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ If using the script fails for some reason, please let us know.
 
 ## Add to path
 
-To use the bindings, you have to add this folder (e.g. `/home/user/matlab-bindings`) to your MATLAB path using [`addpath`](https://de.mathworks.com/help/matlab/ref/addpath.html?searchHighlight=addpath&s_tid=doc_srchtitle). Adding this folder alone is sufficient (you don't have to use `genpath`). You can let MATLAB do this at startup by adding the respective line to your `startup.m`, see [here](https://de.mathworks.com/help/matlab/matlab_env/add-folders-to-matlab-search-path-at-startup.html).
+To use the bindings, you have to add this folder (e.g. `/home/user/matlab-bindings`) to your MATLAB path using [`addpath`](https://de.mathworks.com/help/matlab/ref/addpath.html?searchHighlight=addpath&s_tid=doc_srchtitle). Adding this folder alone is sufficient (you don't have to use `genpath`). You can let MATLAB do this at startup by adding the respective line to your `startup.m` manually, see [here](https://de.mathworks.com/help/matlab/matlab_env/add-folders-to-matlab-search-path-at-startup.html). 
+
+You can also execute the script `add_matlab_bindings_at_startup.m` while located in the matlab-bindings path. It will add the path to the bindings automatically to the `startup.m` file.
 
 ## Usage
 

--- a/add_matlab_bindings_at_startup.m
+++ b/add_matlab_bindings_at_startup.m
@@ -1,1 +1,3 @@
-dlmwrite(fullfile(userpath,'startup.m'), char(addcmd), '-append', 'delimiter', '')
+startupFile = fopen(userpath+"/startup.m", 'a');
+fprintf(startupFile, "addpath "+ pwd + newline);
+fclose(startupFile);

--- a/add_matlab_bindings_at_startup.m
+++ b/add_matlab_bindings_at_startup.m
@@ -1,0 +1,1 @@
+dlmwrite(fullfile(userpath,'startup.m'), char(addcmd), '-append', 'delimiter', '')


### PR DESCRIPTION
The new MATLAB script `add_matlab_bindings_at_startup.m` modifies the `startup.m` file in the user's MATLAB `userpath`.
By adding the path of the matlab-bindings in this file, the bindings are automatically loaded into MATLAB on startup.